### PR TITLE
Fix empty dates. Print an empty string instead of Invalid Date

### DIFF
--- a/addon/helpers/day-of-the-week.js
+++ b/addon/helpers/day-of-the-week.js
@@ -6,6 +6,8 @@ import validArgs from '../utils/valid-args';
 function dayOfTheWeek(date, optionalLocale) {
   validArgs(arguments, 'day-of-the-week');
 
+  if (Ember.isBlank(date)) { return ''; }
+
   var locale = timeLocale(optionalLocale);
 
   return moment(date).locale(locale).format('dddd');

--- a/addon/helpers/time-ago-in-words.js
+++ b/addon/helpers/time-ago-in-words.js
@@ -6,6 +6,8 @@ import validArgs from '../utils/valid-args';
 function timeAgoInWords(date, optionalLocale) {
   validArgs(arguments, 'time-ago-in-words');
 
+  if (Ember.isBlank(date)) { return ''; }
+
   var locale = timeLocale(optionalLocale);
 
   return moment(date).locale(locale).fromNow();

--- a/addon/helpers/time-ahead-in-words.js
+++ b/addon/helpers/time-ahead-in-words.js
@@ -6,6 +6,8 @@ import validArgs from '../utils/valid-args';
 function timeAheadInWords(date, optionalLocale) {
   validArgs(arguments, 'time-ahead-in-words');
 
+  if (Ember.isBlank(date)) { return ''; }
+
   var locale = timeLocale(optionalLocale);
 
   return moment(date).locale(locale).fromNow();

--- a/addon/helpers/time-delta-in-words.js
+++ b/addon/helpers/time-delta-in-words.js
@@ -6,6 +6,8 @@ import validArgs from '../utils/valid-args';
 function timeDeltaInWords(date, optionalLocale) {
   validArgs(arguments, 'time-delta-in-words');
 
+  if (Ember.isBlank(date)) { return ''; }
+
   var locale = timeLocale(optionalLocale);
 
   return moment(date).locale(locale).fromNow();

--- a/addon/helpers/time-format.js
+++ b/addon/helpers/time-format.js
@@ -6,6 +6,8 @@ import validArgs from '../utils/valid-args';
 function timeFormat(date, optionalFormat, optionalLocale) {
   validArgs(arguments, 'time-format');
 
+  if (Ember.isBlank(date)) { return ''; }
+
   var locale = timeLocale(optionalLocale),
       format = 'LL';
 

--- a/tests/unit/helpers/day-of-the-week-test.js
+++ b/tests/unit/helpers/day-of-the-week-test.js
@@ -26,3 +26,11 @@ test('locale pt-br', function() {
   equal(dayOfTheWeek(dateJanuary, 'pt-br', FAKE_HBS_CONTEXT), 'quarta-feira');
 });
 
+test('null date', function() {
+  equal(dayOfTheWeek(null, FAKE_HBS_CONTEXT), '');
+});
+
+
+test('blank date', function() {
+  equal(dayOfTheWeek(' ', FAKE_HBS_CONTEXT), '');
+});

--- a/tests/unit/helpers/time-ago-in-words-test.js
+++ b/tests/unit/helpers/time-ago-in-words-test.js
@@ -21,3 +21,11 @@ test('locale pt-br', function() {
   equal(timeAgoInWords(dateYesterday, 'pt-br', FAKE_HBS_CONTEXT), 'um dia atrás');
 });
 
+test('null date', function() {
+  equal(timeAgoInWords(null, FAKE_HBS_CONTEXT), '');
+});
+
+
+test('blank date', function() {
+  equal(timeAgoInWords(' ', FAKE_HBS_CONTEXT), '');
+});

--- a/tests/unit/helpers/time-ahead-in-words-test.js
+++ b/tests/unit/helpers/time-ahead-in-words-test.js
@@ -21,3 +21,11 @@ test('locale pt-br', function() {
   equal(timeAheadInWords(dateTomorrow, 'pt-br', FAKE_HBS_CONTEXT), 'em um dia');
 });
 
+test('null date', function() {
+  equal(timeAheadInWords(null, FAKE_HBS_CONTEXT), '');
+});
+
+
+test('blank date', function() {
+  equal(timeAheadInWords(' ', FAKE_HBS_CONTEXT), '');
+});

--- a/tests/unit/helpers/time-delta-in-words-test.js
+++ b/tests/unit/helpers/time-delta-in-words-test.js
@@ -21,3 +21,11 @@ test('locale pt-br', function() {
   equal(timeDeltaInWords(dateYesterday, 'pt-br', FAKE_HBS_CONTEXT), 'um dia atrás');
 });
 
+test('null date', function() {
+  equal(timeDeltaInWords(null, FAKE_HBS_CONTEXT), '');
+});
+
+
+test('blank date', function() {
+  equal(timeDeltaInWords(' ', FAKE_HBS_CONTEXT), '');
+});

--- a/tests/unit/helpers/time-format-test.js
+++ b/tests/unit/helpers/time-format-test.js
@@ -38,3 +38,11 @@ test('locale pt-br', function() {
   equal(timeFormat(dateJanuary, 'LL', 'pt-br', FAKE_HBS_CONTEXT), '1 de janeiro de 2014');
 });
 
+test('null date', function() {
+  equal(timeFormat(null, FAKE_HBS_CONTEXT), '');
+});
+
+
+test('blank date', function() {
+  equal(timeFormat(' ', FAKE_HBS_CONTEXT), '');
+});


### PR DESCRIPTION
When a helper is used with an empty date, moment() will print 'Invalid Date' which isn´t a good output to final user.

This pull request will make helper print an empty string ( '' ) instead of 'Invalid Date'.
