### PR TITLE
Updated blueprint to use hard version number. Latest ember-cli-moment…

### DIFF
--- a/blueprints/ember-cli-dates/index.js
+++ b/blueprints/ember-cli-dates/index.js
@@ -8,6 +8,6 @@ module.exports = {
   },
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('ember-cli-moment-shim');
+    return this.addBowerPackageToProject('ember-cli-moment-shim', '0.0.3');
   }
 };


### PR DESCRIPTION
The new versions of ember-cli-moment-shim are an addon, not just a library. Without specifying the exact version, the build process breaks at:

```
Path or pattern "bower_components/ember-cli-moment-shim/moment-shim.js" did not match any files
```

Am I missing something?