### PR TITLE
updated ember install command to new standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It uses moment.js.
 ## Installation
 
 ```
-ember install:addon ember-cli-dates
+ember install ember-cli-dates
 ```
 
 ## Usage


### PR DESCRIPTION
Since ember install:addon has been deprecated
